### PR TITLE
Added Timber alternative (Khronicle)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,4 @@ Projects that use libraries/APIs from the table below must be replaced to use in
 | [GSON](https://github.com/google/gson) | [KotlinX Serialization](https://github.com/Kotlin/kotlinx.serialization) | |
 | [Java I/O](https://docs.oracle.com/javase/8/docs/api/java/io/package-summary.html), [Java NIO](https://docs.oracle.com/javase/8/docs/api/java/nio/package-summary.html) | [OkIO](https://github.com/square/okio)
 | [Dagger/Hilt](https://dagger.dev/) | [Koin](https://github.com/InsertKoinIO/koin), [Kodein](https://github.com/kosi-libs/Kodein), Manual DI, etc. | |
+| [Timber](https://github.com/JakeWharton/timber) | [Khronicle](https://github.com/JuulLabs/khronicle) | |


### PR DESCRIPTION
Hi there!

I've added an alternative to Timber. I hope it will be useful.

There are actually Napier and Kermit for the logging task as well, but they leave strings in the APK after R8, meaning that with these extensions the security of the app is reduced.

I trust this library because it was created by JuulLabs, which also supports the popular and excellent [Kable](https://github.com/JuulLabs/kable), and specifically logging has been evolving [since 2020](https://github.com/JuulLabs/tuulbox/releases/tag/2.3.0), so they support it for almost 4 years.